### PR TITLE
allow other repository host. fix #5

### DIFF
--- a/zpm.c
+++ b/zpm.c
@@ -17,8 +17,11 @@ char* generate_plugin_path(char* plugin_name) {
     char* plugin_path = malloc(PATH_MAX);
     strcpy(plugin_path, getenv("HOME"));
     strcat(plugin_path, "/.zpm/plugins/");
-    strcat(plugin_path, plugin_name);
-
+    if (strncmp(plugin_name, "github.com/", 11)) {
+        strcat(plugin_path, plugin_name);
+    } else {
+        strcat(plugin_path, plugin_name + 11);
+    }
     return plugin_path;
 }
 
@@ -182,6 +185,11 @@ int mkdir_p(const char *path) {
 
 int local_clone_exists(char* plugin_name) {
     char* plugin_path = generate_plugin_path(plugin_name);
+
+    if (!plugin_path) {
+        return -1;
+    }
+
     DIR* plugin_directory = opendir(plugin_path);
 
     if (plugin_directory != NULL) {
@@ -212,6 +220,9 @@ char* generate_repository_url(char* plugin_name) {
     char* url = malloc(PATH_MAX);
     char* tmp = strstr(plugin_name, "/");
 
+    if (!tmp) {
+      return NULL;
+    }
     tmp = strstr(tmp + 1, "/");
     if (!tmp) {
         strcpy(url, "https://github.com/");
@@ -227,6 +238,10 @@ int locally_clone_plugin(char* plugin_name) {
     int ret;
     char* repository_url = generate_repository_url(plugin_name);
     char* clone_destination = generate_plugin_path(plugin_name);
+
+    if (!repository_url) {
+      return -1;
+    }
 
     char* command = malloc(PATH_MAX);
     strcpy(command, "git clone --recursive --depth=1 ");
@@ -328,7 +343,7 @@ int main(int argc, char* argv[]) {
         strcpy(plugin_name, plugin_name_or_command);
     }
 
-    int status = 0;
+    int status = strstr(plugin_name, "/") ? 0 : -1;
     char* install = malloc(1024);
     strcpy(install, "Installing ");
     strcat(install, plugin_name);

--- a/zpm.c
+++ b/zpm.c
@@ -213,10 +213,11 @@ char* generate_repository_url(char* plugin_name) {
     char* tmp = strstr(plugin_name, "/");
 
     tmp = strstr(tmp + 1, "/");
-    if(!tmp)
+    if (!tmp) {
         strcpy(url, "https://github.com/");
-    else
+    } else {
         strcpy(url, "https://");
+    }
     strcat(url, plugin_name);
 
     return url;

--- a/zpm.c
+++ b/zpm.c
@@ -210,7 +210,13 @@ int zpm_configuration_exists() {
 
 char* generate_repository_url(char* plugin_name) {
     char* url = malloc(PATH_MAX);
-    strcpy(url, "https://github.com/");
+    char* tmp = strstr(plugin_name, "/");
+
+    tmp = strstr(tmp + 1, "/");
+    if(!tmp)
+        strcpy(url, "https://github.com/");
+    else
+        strcpy(url, "https://");
     strcat(url, plugin_name);
 
     return url;


### PR DESCRIPTION
It just assumes that if there is only one slash in the path, plugin is to be found on github.